### PR TITLE
Fix TextAnalytics sku

### DIFF
--- a/cloud/infra/template.json
+++ b/cloud/infra/template.json
@@ -37,7 +37,7 @@
       "kind": "TextAnalytics",
       "name": "[concat(parameters('prefix'), 'clu', parameters('suffix'))]",
       "Sku": {
-        "Name": "S0"
+        "Name": "S"
       }
     },
     {


### PR DESCRIPTION
S0-S4 TextAnalytics have been retired so deploying this template produces an error. There is just an S sku now.

https://blog.jongallant.com/2021/04/solution-subscription-does-not-have-quotaid-feature-required-by-sku/